### PR TITLE
feat(chat): 채팅 메시지에 여러 파일 업로드 지원

### DIFF
--- a/src/main/java/com/jamjam/chat/application/ChatService.java
+++ b/src/main/java/com/jamjam/chat/application/ChatService.java
@@ -246,6 +246,50 @@ public class ChatService {
         }
     }
 
+    @Transactional
+    public List<ChatFileUploadRes> uploadChatFiles(Long roomId, String userId, List<MultipartFile> files) {
+        ChatRoomEntity room = roomRepo.findById(roomId)
+                .orElseThrow(() -> new ApiException(ChatError.ROOM_NOT_FOUND));
+
+        partRepo.findByRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new ApiException(ChatError.NOT_PARTICIPANT));
+
+        if (files == null || files.isEmpty()) {
+            throw new ApiException(ChatError.FILE_NOT_PROVIDED);
+        }
+
+        if (files.size() > 10) {
+            throw new ApiException(ChatError.TOO_MANY_FILES);
+        }
+
+        return files.stream()
+                .map(file -> {
+                    if (file.isEmpty()) {
+                        throw new ApiException(ChatError.FILE_NOT_PROVIDED);
+                    }
+
+                    if (file.getSize() > 10 * 1024 * 1024) {
+                        throw new ApiException(ChatError.FILE_SIZE_EXCEEDED);
+                    }
+
+                    MessageType messageType = validateAndGetMessageType(file);
+
+                    try {
+                        String fileUrl = s3Uploader.upload(file, "chat-files");
+                        return new ChatFileUploadRes(
+                                fileUrl,
+                                file.getOriginalFilename(),
+                                file.getSize(),
+                                messageType
+                        );
+                    } catch (IOException e) {
+                        log.error("파일 업로드 실패: {}", e.getMessage());
+                        throw new ApiException(ChatError.FILE_UPLOAD_FAILED);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
     private MessageType validateAndGetMessageType(MultipartFile file) {
         String contentType = file.getContentType();
         String fileName = file.getOriginalFilename();

--- a/src/main/java/com/jamjam/chat/exception/ChatError.java
+++ b/src/main/java/com/jamjam/chat/exception/ChatError.java
@@ -11,7 +11,8 @@ public enum ChatError implements ErrorCode {
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기는 10MB를 초과할 수 없습니다.", "FILE_SIZE_EXCEEDED"),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다.", "INVALID_FILE_TYPE"),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.", "FILE_UPLOAD_FAILED"),
-    FILE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "파일이 제공되지 않았습니다.", "FILE_NOT_PROVIDED");
+    FILE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "파일이 제공되지 않았습니다.", "FILE_NOT_PROVIDED"),
+    TOO_MANY_FILES(HttpStatus.BAD_REQUEST, "파일은 최대 10개까지 업로드할 수 있습니다.", "TOO_MANY_FILES");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/jamjam/chat/presentation/ChatController.java
+++ b/src/main/java/com/jamjam/chat/presentation/ChatController.java
@@ -86,7 +86,9 @@
                         - 이미지: jpg, jpeg, png, gif
                         - 문서: pdf, doc, docx, xls, xlsx, zip, txt
 
-                        **파일 크기 제한:** 최대 10MB
+                        **파일 크기 제한:** 각 파일 최대 10MB
+
+                        **파일 개수:** 한 번에 최대 10개까지 업로드 가능
 
                         **사용 방법:**
                         1. 이 API로 파일을 업로드하여 fileUrl, fileName, fileSize, messageType을 받습니다
@@ -124,31 +126,33 @@
                                                 {
                                                   "success": true,
                                                   "message": "작업이 성공적으로 완료되었습니다.",
-                                                  "data": {
-                                                    "fileUrl": "https://jamjam2025.s3.amazonaws.com/chat-files/550e8400-e29b-41d4-a716-446655440000_photo.jpg",
-                                                    "fileName": "photo.jpg",
-                                                    "fileSize": 102400,
-                                                    "messageType": "IMAGE"
-                                                  }
+                                                  "data": [
+                                                    {
+                                                      "fileUrl": "https://jamjam2025.s3.amazonaws.com/chat-files/550e8400-e29b-41d4-a716-446655440000_photo.jpg",
+                                                      "fileName": "photo.jpg",
+                                                      "fileSize": 102400,
+                                                      "messageType": "IMAGE"
+                                                    }
+                                                  ]
                                                 }
                                                 """
                                 )
                         )
                 )
         })
-        public ResponseEntity<ResponseDto<ChatFileUploadRes>> uploadChatFile(
+        public ResponseEntity<ResponseDto<List<ChatFileUploadRes>>> uploadChatFile(
                 @Parameter(hidden = true) @CurrentUser CustomUserDetails user,
                 @Parameter(
-                        description = "업로드할 파일 (이미지: jpg/jpeg/png/gif, 문서: pdf/doc/docx/xls/xlsx/zip/txt)",
+                        description = "업로드할 파일들 (이미지: jpg/jpeg/png/gif, 문서: pdf/doc/docx/xls/xlsx/zip/txt)",
                         required = true,
                         content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
                 )
-                @RequestPart("file") MultipartFile file,
+                @RequestPart("files") List<MultipartFile> files,
                 @Parameter(description = "채팅방 ID", required = true, example = "1")
                 @RequestParam Long roomId
         ) {
-            ChatFileUploadRes res = chatService.uploadChatFile(roomId, String.valueOf(user.getUserId()), file);
-            return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, res));
+            List<ChatFileUploadRes> results = chatService.uploadChatFiles(roomId, String.valueOf(user.getUserId()), files);
+            return ResponseEntity.ok(ResponseDto.ofSuccess(SuccessMessage.OPERATION_SUCCESS, results));
         }
 
         @PostMapping("/room")

--- a/src/test/java/com/jamjam/chat/application/ChatServiceTest.java
+++ b/src/test/java/com/jamjam/chat/application/ChatServiceTest.java
@@ -21,10 +21,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -380,5 +382,217 @@ class ChatServiceTest {
 
         // then
         assertThat(result.messageType()).isEqualTo(MessageType.FILE);
+    }
+
+    @Test
+    @DisplayName("여러 파일 업로드 성공 - 2개 파일")
+    void uploadChatFiles_Two_Success() throws IOException {
+        // given
+        Long roomId = 1L;
+        String userId = "1";
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "files",
+                "image1.jpg",
+                "image/jpeg",
+                "image content".getBytes()
+        );
+
+        MockMultipartFile pdfFile = new MockMultipartFile(
+                "files",
+                "document.pdf",
+                "application/pdf",
+                "pdf content".getBytes()
+        );
+
+        List<MultipartFile> files = List.of(imageFile, pdfFile);
+
+        String imageUrl = "https://jamjam2025.s3.amazonaws.com/chat-files/image1.jpg";
+        String pdfUrl = "https://jamjam2025.s3.amazonaws.com/chat-files/document.pdf";
+
+        given(roomRepo.findById(roomId)).willReturn(Optional.of(chatRoom));
+        given(partRepo.findByRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(participant));
+        given(s3Uploader.upload(imageFile, "chat-files")).willReturn(imageUrl);
+        given(s3Uploader.upload(pdfFile, "chat-files")).willReturn(pdfUrl);
+
+        // when
+        List<ChatFileUploadRes> results = chatService.uploadChatFiles(roomId, userId, files);
+
+        // then
+        assertThat(results).hasSize(2);
+
+        assertThat(results.get(0).fileUrl()).isEqualTo(imageUrl);
+        assertThat(results.get(0).fileName()).isEqualTo("image1.jpg");
+        assertThat(results.get(0).messageType()).isEqualTo(MessageType.IMAGE);
+        assertThat(results.get(0).fileSize()).isEqualTo(imageFile.getSize());
+
+        assertThat(results.get(1).fileUrl()).isEqualTo(pdfUrl);
+        assertThat(results.get(1).fileName()).isEqualTo("document.pdf");
+        assertThat(results.get(1).messageType()).isEqualTo(MessageType.FILE);
+        assertThat(results.get(1).fileSize()).isEqualTo(pdfFile.getSize());
+
+        verify(s3Uploader, times(1)).upload(imageFile, "chat-files");
+        verify(s3Uploader, times(1)).upload(pdfFile, "chat-files");
+    }
+
+    @Test
+    @DisplayName("여러 파일 업로드 성공 - 3개 파일 (이미지 2개 + 문서 1개)")
+    void uploadChatFiles_Three_Success() throws IOException {
+        // given
+        Long roomId = 1L;
+        String userId = "1";
+
+        MockMultipartFile image1 = new MockMultipartFile(
+                "files",
+                "photo1.jpg",
+                "image/jpeg",
+                "photo1 content".getBytes()
+        );
+
+        MockMultipartFile image2 = new MockMultipartFile(
+                "files",
+                "photo2.png",
+                "image/png",
+                "photo2 content".getBytes()
+        );
+
+        MockMultipartFile doc = new MockMultipartFile(
+                "files",
+                "report.docx",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "docx content".getBytes()
+        );
+
+        List<MultipartFile> files = List.of(image1, image2, doc);
+
+        given(roomRepo.findById(roomId)).willReturn(Optional.of(chatRoom));
+        given(partRepo.findByRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(participant));
+        given(s3Uploader.upload(any(), eq("chat-files")))
+                .willReturn("https://s3.amazonaws.com/file1.jpg")
+                .willReturn("https://s3.amazonaws.com/file2.png")
+                .willReturn("https://s3.amazonaws.com/file3.docx");
+
+        // when
+        List<ChatFileUploadRes> results = chatService.uploadChatFiles(roomId, userId, files);
+
+        // then
+        assertThat(results).hasSize(3);
+        assertThat(results.get(0).messageType()).isEqualTo(MessageType.IMAGE);
+        assertThat(results.get(1).messageType()).isEqualTo(MessageType.IMAGE);
+        assertThat(results.get(2).messageType()).isEqualTo(MessageType.FILE);
+
+        verify(s3Uploader, times(3)).upload(any(), eq("chat-files"));
+    }
+
+    @Test
+    @DisplayName("여러 파일 업로드 실패 - 파일 리스트가 비어있음")
+    void uploadChatFiles_EmptyList() {
+        // given
+        Long roomId = 1L;
+        String userId = "1";
+        List<MultipartFile> emptyFiles = List.of();
+
+        given(roomRepo.findById(roomId)).willReturn(Optional.of(chatRoom));
+        given(partRepo.findByRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(participant));
+
+        // when & then
+        assertThatThrownBy(() -> chatService.uploadChatFiles(roomId, userId, emptyFiles))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("파일이 제공되지 않았습니다");
+    }
+
+    @Test
+    @DisplayName("여러 파일 업로드 실패 - 파일 개수 초과 (11개)")
+    void uploadChatFiles_TooManyFiles() {
+        // given
+        Long roomId = 1L;
+        String userId = "1";
+
+        List<MultipartFile> tooManyFiles = List.of(
+                new MockMultipartFile("files", "file1.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file2.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file3.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file4.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file5.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file6.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file7.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file8.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file9.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file10.jpg", "image/jpeg", "content".getBytes()),
+                new MockMultipartFile("files", "file11.jpg", "image/jpeg", "content".getBytes())
+        );
+
+        given(roomRepo.findById(roomId)).willReturn(Optional.of(chatRoom));
+        given(partRepo.findByRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(participant));
+
+        // when & then
+        assertThatThrownBy(() -> chatService.uploadChatFiles(roomId, userId, tooManyFiles))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("파일은 최대 10개까지 업로드할 수 있습니다");
+    }
+
+    @Test
+    @DisplayName("여러 파일 업로드 실패 - 파일 중 하나가 비어있음")
+    void uploadChatFiles_OneFileEmpty() {
+        // given
+        Long roomId = 1L;
+        String userId = "1";
+
+        MockMultipartFile validFile = new MockMultipartFile(
+                "files",
+                "valid.jpg",
+                "image/jpeg",
+                "content".getBytes()
+        );
+
+        MockMultipartFile emptyFile = new MockMultipartFile(
+                "files",
+                "empty.jpg",
+                "image/jpeg",
+                new byte[0]
+        );
+
+        List<MultipartFile> files = List.of(validFile, emptyFile);
+
+        given(roomRepo.findById(roomId)).willReturn(Optional.of(chatRoom));
+        given(partRepo.findByRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(participant));
+
+        // when & then
+        assertThatThrownBy(() -> chatService.uploadChatFiles(roomId, userId, files))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("파일이 제공되지 않았습니다");
+    }
+
+    @Test
+    @DisplayName("여러 파일 업로드 실패 - 파일 중 하나가 크기 초과")
+    void uploadChatFiles_OneFileTooLarge() {
+        // given
+        Long roomId = 1L;
+        String userId = "1";
+
+        MockMultipartFile validFile = new MockMultipartFile(
+                "files",
+                "small.jpg",
+                "image/jpeg",
+                "small content".getBytes()
+        );
+
+        byte[] largeContent = new byte[11 * 1024 * 1024]; // 11MB
+        MockMultipartFile largeFile = new MockMultipartFile(
+                "files",
+                "large.jpg",
+                "image/jpeg",
+                largeContent
+        );
+
+        List<MultipartFile> files = List.of(validFile, largeFile);
+
+        given(roomRepo.findById(roomId)).willReturn(Optional.of(chatRoom));
+        given(partRepo.findByRoomIdAndUserId(roomId, userId)).willReturn(Optional.of(participant));
+
+        // when & then
+        assertThatThrownBy(() -> chatService.uploadChatFiles(roomId, userId, files))
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining("10MB를 초과할 수 없습니다");
     }
 }

--- a/src/test/java/com/jamjam/chat/presentation/ChatControllerTest.java
+++ b/src/test/java/com/jamjam/chat/presentation/ChatControllerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import java.util.List;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -62,7 +63,7 @@ class ChatControllerTest {
         // given
         Long roomId = 1L;
         MockMultipartFile file = new MockMultipartFile(
-                "file",
+                "files",
                 "test-image.jpg",
                 "image/jpeg",
                 "test image content".getBytes()
@@ -75,7 +76,7 @@ class ChatControllerTest {
                 MessageType.IMAGE
         );
 
-        given(chatService.uploadChatFile(eq(roomId), anyString(), any())).willReturn(response);
+        given(chatService.uploadChatFiles(eq(roomId), anyString(), anyList())).willReturn(List.of(response));
 
         // when & then
         mockMvc.perform(multipart("/api/chat/upload-file")
@@ -86,12 +87,12 @@ class ChatControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.fileUrl").value("https://jamjam2025.s3.amazonaws.com/chat-files/test-image.jpg"))
-                .andExpect(jsonPath("$.data.fileName").value("test-image.jpg"))
-                .andExpect(jsonPath("$.data.messageType").value("IMAGE"))
-                .andExpect(jsonPath("$.data.fileSize").value(file.getSize()));
+                .andExpect(jsonPath("$.data[0].fileUrl").value("https://jamjam2025.s3.amazonaws.com/chat-files/test-image.jpg"))
+                .andExpect(jsonPath("$.data[0].fileName").value("test-image.jpg"))
+                .andExpect(jsonPath("$.data[0].messageType").value("IMAGE"))
+                .andExpect(jsonPath("$.data[0].fileSize").value(file.getSize()));
 
-        verify(chatService, times(1)).uploadChatFile(eq(roomId), anyString(), any());
+        verify(chatService, times(1)).uploadChatFiles(eq(roomId), anyString(), anyList());
     }
 
     @Test
@@ -101,7 +102,7 @@ class ChatControllerTest {
         // given
         Long roomId = 1L;
         MockMultipartFile file = new MockMultipartFile(
-                "file",
+                "files",
                 "document.pdf",
                 "application/pdf",
                 "test pdf content".getBytes()
@@ -114,7 +115,7 @@ class ChatControllerTest {
                 MessageType.FILE
         );
 
-        given(chatService.uploadChatFile(eq(roomId), anyString(), any())).willReturn(response);
+        given(chatService.uploadChatFiles(eq(roomId), anyString(), anyList())).willReturn(List.of(response));
 
         // when & then
         mockMvc.perform(multipart("/api/chat/upload-file")
@@ -125,11 +126,11 @@ class ChatControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.fileUrl").value("https://jamjam2025.s3.amazonaws.com/chat-files/document.pdf"))
-                .andExpect(jsonPath("$.data.fileName").value("document.pdf"))
-                .andExpect(jsonPath("$.data.messageType").value("FILE"));
+                .andExpect(jsonPath("$.data[0].fileUrl").value("https://jamjam2025.s3.amazonaws.com/chat-files/document.pdf"))
+                .andExpect(jsonPath("$.data[0].fileName").value("document.pdf"))
+                .andExpect(jsonPath("$.data[0].messageType").value("FILE"));
 
-        verify(chatService, times(1)).uploadChatFile(eq(roomId), anyString(), any());
+        verify(chatService, times(1)).uploadChatFiles(eq(roomId), anyString(), anyList());
     }
 
     @Test
@@ -138,7 +139,7 @@ class ChatControllerTest {
     void uploadChatFile_MissingRoomId() throws Exception {
         // given
         MockMultipartFile file = new MockMultipartFile(
-                "file",
+                "files",
                 "test.jpg",
                 "image/jpeg",
                 "test".getBytes()
@@ -175,7 +176,7 @@ class ChatControllerTest {
         // given
         Long roomId = 1L;
         MockMultipartFile file = new MockMultipartFile(
-                "file",
+                "files",
                 "test.jpg",
                 "image/jpeg",
                 "test".getBytes()
@@ -197,7 +198,7 @@ class ChatControllerTest {
         // given
         Long roomId = 1L;
         MockMultipartFile file = new MockMultipartFile(
-                "file",
+                "files",
                 "screenshot.png",
                 "image/png",
                 "png content".getBytes()
@@ -210,7 +211,7 @@ class ChatControllerTest {
                 MessageType.IMAGE
         );
 
-        given(chatService.uploadChatFile(eq(roomId), anyString(), any())).willReturn(response);
+        given(chatService.uploadChatFiles(eq(roomId), anyString(), anyList())).willReturn(List.of(response));
 
         // when & then
         mockMvc.perform(multipart("/api/chat/upload-file")
@@ -220,7 +221,7 @@ class ChatControllerTest {
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.messageType").value("IMAGE"));
+                .andExpect(jsonPath("$.data[0].messageType").value("IMAGE"));
     }
 
     @Test
@@ -230,7 +231,7 @@ class ChatControllerTest {
         // given
         Long roomId = 1L;
         MockMultipartFile file = new MockMultipartFile(
-                "file",
+                "files",
                 "report.docx",
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                 "docx content".getBytes()
@@ -243,7 +244,7 @@ class ChatControllerTest {
                 MessageType.FILE
         );
 
-        given(chatService.uploadChatFile(eq(roomId), anyString(), any())).willReturn(response);
+        given(chatService.uploadChatFiles(eq(roomId), anyString(), anyList())).willReturn(List.of(response));
 
         // when & then
         mockMvc.perform(multipart("/api/chat/upload-file")
@@ -253,7 +254,7 @@ class ChatControllerTest {
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.messageType").value("FILE"));
+                .andExpect(jsonPath("$.data[0].messageType").value("FILE"));
     }
 
     @Test
@@ -263,7 +264,7 @@ class ChatControllerTest {
         // given
         Long roomId = 1L;
         MockMultipartFile file = new MockMultipartFile(
-                "file",
+                "files",
                 "archive.zip",
                 "application/zip",
                 "zip content".getBytes()
@@ -276,7 +277,7 @@ class ChatControllerTest {
                 MessageType.FILE
         );
 
-        given(chatService.uploadChatFile(eq(roomId), anyString(), any())).willReturn(response);
+        given(chatService.uploadChatFiles(eq(roomId), anyString(), anyList())).willReturn(List.of(response));
 
         // when & then
         mockMvc.perform(multipart("/api/chat/upload-file")
@@ -286,7 +287,7 @@ class ChatControllerTest {
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.messageType").value("FILE"));
+                .andExpect(jsonPath("$.data[0].messageType").value("FILE"));
     }
 
     @Test
@@ -296,7 +297,7 @@ class ChatControllerTest {
         // given
         Long roomId = 1L;
         MockMultipartFile file = new MockMultipartFile(
-                "file",
+                "files",
                 "채팅_이미지.jpg",
                 "image/jpeg",
                 "image content".getBytes()
@@ -309,7 +310,7 @@ class ChatControllerTest {
                 MessageType.IMAGE
         );
 
-        given(chatService.uploadChatFile(eq(roomId), anyString(), any())).willReturn(response);
+        given(chatService.uploadChatFiles(eq(roomId), anyString(), anyList())).willReturn(List.of(response));
 
         // when & then
         mockMvc.perform(multipart("/api/chat/upload-file")
@@ -319,6 +320,76 @@ class ChatControllerTest {
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.fileName").value("채팅_이미지.jpg"));
+                .andExpect(jsonPath("$.data[0].fileName").value("채팅_이미지.jpg"));
+    }
+
+    @Test
+    @DisplayName("채팅 파일 업로드 API - 여러 파일 업로드 성공")
+    @WithMockUser
+    void uploadChatFiles_Multiple_Success() throws Exception {
+        // given
+        Long roomId = 1L;
+        MockMultipartFile file1 = new MockMultipartFile(
+                "files",
+                "image1.jpg",
+                "image/jpeg",
+                "image1 content".getBytes()
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "files",
+                "image2.png",
+                "image/png",
+                "image2 content".getBytes()
+        );
+        MockMultipartFile file3 = new MockMultipartFile(
+                "files",
+                "document.pdf",
+                "application/pdf",
+                "pdf content".getBytes()
+        );
+
+        List<ChatFileUploadRes> responses = List.of(
+                new ChatFileUploadRes(
+                        "https://jamjam2025.s3.amazonaws.com/chat-files/image1.jpg",
+                        "image1.jpg",
+                        file1.getSize(),
+                        MessageType.IMAGE
+                ),
+                new ChatFileUploadRes(
+                        "https://jamjam2025.s3.amazonaws.com/chat-files/image2.png",
+                        "image2.png",
+                        file2.getSize(),
+                        MessageType.IMAGE
+                ),
+                new ChatFileUploadRes(
+                        "https://jamjam2025.s3.amazonaws.com/chat-files/document.pdf",
+                        "document.pdf",
+                        file3.getSize(),
+                        MessageType.FILE
+                )
+        );
+
+        given(chatService.uploadChatFiles(eq(roomId), anyString(), anyList())).willReturn(responses);
+
+        // when & then
+        mockMvc.perform(multipart("/api/chat/upload-file")
+                        .file(file1)
+                        .file(file2)
+                        .file(file3)
+                        .param("roomId", roomId.toString())
+                        .with(user(mockUser))
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].fileName").value("image1.jpg"))
+                .andExpect(jsonPath("$.data[0].messageType").value("IMAGE"))
+                .andExpect(jsonPath("$.data[1].fileName").value("image2.png"))
+                .andExpect(jsonPath("$.data[1].messageType").value("IMAGE"))
+                .andExpect(jsonPath("$.data[2].fileName").value("document.pdf"))
+                .andExpect(jsonPath("$.data[2].messageType").value("FILE"));
+
+        verify(chatService, times(1)).uploadChatFiles(eq(roomId), anyString(), anyList());
     }
 }


### PR DESCRIPTION
  - 한 번에 최대 10개 파일 업로드 가능
  - uploadChatFiles 메서드 추가
  - 파일 개수 초과 에러 추가
  - 여러 파일 업로드 테스트 케이스 추가

## 💡 ISSUE
<!-- 연관 이슈 번호 EX) #이슈번호 및 기능/수정 이유 요약 -->
- close #

## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->

## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
