### PR TITLE
feat(chat): 중복 1:1 채팅방 생성 방지

### DIFF
--- a/src/main/java/com/jamjam/chat/application/ChatService.java
+++ b/src/main/java/com/jamjam/chat/application/ChatService.java
@@ -38,6 +38,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -141,6 +142,14 @@ public class ChatService {
 
     @Transactional
     public CreateRoomRes createRoom(boolean groupChat, List<String> userIds) {
+
+        if (userIds.size() == 2) {
+            Optional<ChatRoomEntity> existingRoom = roomRepo.findExistingDirectChat(
+                    userIds.get(0), userIds.get(1));
+            if (existingRoom.isPresent()) {
+                return new CreateRoomRes(existingRoom.get().getId());
+            }
+        }
 
         ChatRoomEntity room = roomRepo.save(ChatRoomEntity.builder()
                 .groupChat(groupChat)

--- a/src/main/java/com/jamjam/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/jamjam/chat/domain/repository/ChatRoomRepository.java
@@ -2,6 +2,17 @@ package com.jamjam.chat.domain.repository;
 
 import com.jamjam.chat.domain.entity.ChatRoomEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
+
+    @Query("SELECT r FROM ChatRoomEntity r " +
+           "WHERE r.groupChat = false " +
+           "AND SIZE(r.participants) = 2 " +
+           "AND EXISTS (SELECT 1 FROM ChatRoomParticipantEntity p WHERE p.room = r AND p.userId = :userId1) " +
+           "AND EXISTS (SELECT 1 FROM ChatRoomParticipantEntity p WHERE p.room = r AND p.userId = :userId2)")
+    Optional<ChatRoomEntity> findExistingDirectChat(@Param("userId1") String userId1, @Param("userId2") String userId2);
 }


### PR DESCRIPTION
## ✅ KEY-CHANGES
<!-- 작업내용 설명 -->
  - 같은 참여자로 1:1 채팅방 생성 요청 시 기존 채팅방이 있으면 새로 만들지 않고 기존 방 ID 반환합니다.                                                             
  - 동일한 상대와 여러 개의 채팅방이 생성되는 문제를 해결합니다.
## 💬 TO REVIEWER
<!-- 참고사항 설명 -->
